### PR TITLE
Handle missing taxonomy ranks when building consensus lineage

### DIFF
--- a/scripts/summarize_kraken2_reports.py
+++ b/scripts/summarize_kraken2_reports.py
@@ -57,13 +57,17 @@ def get_consensus_lineage(taxon_id: str, ncbi: NCBITaxa) -> str:
                 f"Taxon ID {taxon_id} not found in NCBI taxonomy database."
             )
 
-        lineage_parts = []
+        lineage_rank_to_name: dict[str, str] = {}
         for taxid in lineage:
             rank = lineage_ranks.get(taxid)
             if rank in ncbi_rank_to_prefix:
-                prefix = ncbi_rank_to_prefix[rank]
-                name = names.get(taxid, "unknown")
-                lineage_parts.append(f"{prefix}{name}")
+                name = names.get(taxid, "")
+                lineage_rank_to_name[rank] = name
+
+        lineage_parts = []
+        for rank, prefix in ncbi_rank_to_prefix.items():
+            name = lineage_rank_to_name.get(rank, "")
+            lineage_parts.append(f"{prefix}{name}")
 
         return "; ".join(lineage_parts)
     except Exception as e:

--- a/scripts/test_summarize_kraken2_reports.py
+++ b/scripts/test_summarize_kraken2_reports.py
@@ -40,3 +40,13 @@ def test_get_consensus_lineage():
     assert (
         get_consensus_lineage("000000", ncbi) == "unknown"
     ), "Unknown taxon ID should return 'unknown'"
+
+
+def test_get_consensus_lineage_with_missing_family():
+    ncbi = update_ncbi_taxonomy()
+    lineage = get_consensus_lineage("754249", ncbi)
+    expected = (
+        "k__Bacteria; p__Actinomycetota; c__Actinomycetes; o__Micrococcales; "
+        "f__; g__Luteimicrobium; s__"
+    )
+    assert lineage == expected, f"Expected: {expected}, Got: {lineage}"


### PR DESCRIPTION
## Summary
- ensure consensus lineage strings emit placeholders for all supported taxonomic ranks
- add a regression test covering taxa without a formal family assignment

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'ete3')*


------
https://chatgpt.com/codex/tasks/task_e_690a49f8ba3c8323870d51686a023314